### PR TITLE
Disable lockfile maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,6 @@
   "branchPrefix": "renovate-",
   "commitMessageAction": "Renovate Update",
   "labels": ["Dependencies", "Renovate"],
-  "lockFileMaintenance": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "automerge": true,


### PR DESCRIPTION
Turn off lockfile maintenance in Renovate: it only updates transient dependencies, which creates lots of noise and doesn't provide us with any benefit