### PR TITLE
VEGA 1853 design changes

### DIFF
--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -12,37 +12,40 @@ describe('Search component', () => {
         it('Displays basic case information', () => {
             search('Giusto', 'single.json');
 
-            cy.contains('.sirius-search__item', 'Giusto Rita [Donor]').within(() => {
-                cy.contains('a', '7000-2910-9383 LPA/HW').should('have.attr', 'href', '/lpa/person/75/14');
+            cy.contains('.sirius-search__item', 'Giusto Rita, Donor').within(() => {
+                cy.contains('a', '7000-2910-9383').should('have.attr', 'href', '/lpa/person/75/14');
 
                 cy.contains('dt', 'DOB').next().contains('19/01/1934');
                 cy.contains('dt', 'Address').next().contains('9046 Harvey Track, Suite 540, Violaport, Lothian, EQ4 1PR, United Kingdom');
                 cy.contains('dt', 'Status').next().contains('Pending');
+                cy.contains('dt', 'Type').next().contains('LPA - Health and welfare');
             });
         });
 
         it('Expands cases', () => {
             search('Lloyd', 'multiple.json');
 
-            cy.get('.sirius-search__item:contains(Lloyd Poullard [Donor])')
+            cy.get('.sirius-search__item:contains(Lloyd Poullard, Donor)')
                 .eq(0)
                 .within(() => {
-                    cy.contains('a', '7000-2910-2948 LPA/HW').should('have.attr', 'href', '/lpa/person/94/315');
+                    cy.contains('a', '7000-2910-2948').should('have.attr', 'href', '/lpa/person/94/315');
                     cy.contains('dt', 'Status').next().contains('Registered');
+                    cy.contains('dt', 'Type').next().contains('LPA - Health and welfare');
                 });
 
-            cy.get('.sirius-search__item:contains(Lloyd Poullard [Donor])')
+            cy.get('.sirius-search__item:contains(Lloyd Poullard, Donor)')
                 .eq(1)
                 .within(() => {
-                    cy.contains('a', '7000-2910-1244 LPA/PFA').should('have.attr', 'href', '/lpa/person/94/219');
+                    cy.contains('a', '7000-2910-1244').should('have.attr', 'href', '/lpa/person/94/219');
                     cy.contains('dt', 'Status').next().contains('Pending');
+                    cy.contains('dt', 'Type').next().contains('LPA - Property and finance');
                 });
         });
 
         it('Hides cases if they overflow', () => {
             search('Test', 'overflow.json');
 
-            cy.get('.sirius-search__item:contains([Donor])').should('have.length', 3);
+            cy.get('.sirius-search__item:contains(Donor)').should('have.length', 3);
         });
 
         it('Formats status correctly', () => {

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -38,3 +38,25 @@ const statusColourMap = {
 export function statusColour(status) {
   return statusColourMap[status] || "grey";
 }
+
+export function translateSubtype(subtype) {
+  let t
+  switch(subtype.toUpperCase()) {
+    case "HW":
+      t = "Health and welfare"
+      break;
+    case "PFA":
+      t = "Property and finance"
+      break;
+    case "PA":
+      t = "Property affairs"
+      break;
+    case "PW":
+      t = "Personal welfare"
+      break;
+    default:
+      t = subtype
+  }
+
+  return t
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import { query, queryDeletedCases } from "./lib/api";
-import { escapeHTML, formatAddress, statusColour } from "./lib/format";
+import {escapeHTML, formatAddress, statusColour, translateSubtype} from "./lib/format";
 
 const CLASSES = {
   container: "sirius-search",
@@ -157,19 +157,16 @@ SearchResults.prototype.search = async function search() {
           .map(
             (result) => `
                 <li class="${CLASSES.item}">
-                    <strong>
+                    <strong class="sirius-search--colour-text-blue">
                       ${escapeHTML(result.firstname)} ${escapeHTML(
               result.surname
-            )} [${result.personType}]
+            )}, ${result.personType}
                     </strong>
                     <p class="${CLASSES.link}">
                         <a class="govuk-link" href="/lpa/person/${result.id}/${
               result.case.id
             }">
                             ${result.case.uId}
-                            ${
-                              result.case.caseType
-                            }/${result.case.caseSubtype.toUpperCase()}
                         </a>
                     </p>
                     <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-0">
@@ -203,6 +200,12 @@ SearchResults.prototype.search = async function search() {
                         `
                             : ""
                         }
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key govuk-!-padding-top-1 govuk-!-padding-bottom-1">Type:</dt>
+                            <dd class="govuk-summary-list__value govuk-!-padding-top-1 govuk-!-padding-bottom-1">
+                            ${result.case.caseType} - ${ translateSubtype(result.case.caseSubtype.toUpperCase()) }
+                            </dd>
+                        </div>
                     </dl>
                 </li>
             `

--- a/src/main.js
+++ b/src/main.js
@@ -202,8 +202,9 @@ SearchResults.prototype.search = async function search() {
                         }
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key govuk-!-padding-top-1 govuk-!-padding-bottom-1">Type:</dt>
-                            <dd class="govuk-summary-list__value govuk-!-padding-top-1 govuk-!-padding-bottom-1">
-                            ${result.case.caseType} - ${ translateSubtype(result.case.caseSubtype.toUpperCase()) }
+                            <dd class="govuk-summary-list__value govuk-!-padding-top-1 govuk-!-padding-bottom-1">${
+                                result.case.caseType.toUpperCase() === "DIGITAL_LPA" ? "Digital LPA" : result.case.caseType
+                                } - ${ translateSubtype(result.case.caseSubtype.toUpperCase()) }
                             </dd>
                         </div>
                     </dl>
@@ -216,7 +217,7 @@ SearchResults.prototype.search = async function search() {
             Showing <strong data-id="sirius-search-summary-count">${
               results.length
             }</strong> of <strong>${total}</strong> results
-            <a class="govuk-link" href="/lpa/frontend/search?term=${escapeHTML(searchTerm)}" target="_self" style="float:right">View all</a>
+            <a class="govuk-link sirius-search__link--view-all" href="/lpa/frontend/search?term=${escapeHTML(searchTerm)}" target="_self">View all</a>
         </div>
     `);
 

--- a/src/search.css
+++ b/src/search.css
@@ -31,3 +31,7 @@
 .sirius-seach .govuk-link {
   font-size: 1rem;
 }
+
+.sirius-search--colour-text-blue {
+  color: #1d70b8
+}

--- a/src/search.css
+++ b/src/search.css
@@ -35,3 +35,7 @@
 .sirius-search--colour-text-blue {
   color: #1d70b8
 }
+
+.sirius-search__link--view-all {
+  float: right;
+}


### PR DESCRIPTION
Now that we are including this component in the header, there are a few design tweaks requested since the original design was made. These include:

- Removing square brackets from the actor type
- Changing the actor name & type text to blue
- Moving the type and subtype to a new section and writing out the subtype in full eg "Type: LPA - Health and welfare"

VEGA-1853 #patch