### PR TITLE
Update digital LPA links in search results

### DIFF
--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -72,7 +72,7 @@ describe('Search component', () => {
             search('Lloyd', 'multiple.json');
 
             cy.contains('.govuk-tag', 'Registered').should('have.class', 'govuk-tag--green');
-            cy.contains('.govuk-tag', 'Pending').should('have.class', 'govuk-tag--yellow');
+            cy.contains('.govuk-tag', 'Pending').should('have.class', 'govuk-tag--blue');
         });
     });
 

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -48,7 +48,7 @@ describe('Search component', () => {
             cy.get('.sirius-search__item:contains(Abelard Brroo, Donor)')
                 .eq(0)
                 .within(() => {
-                    cy.contains('a', 'M-QQQQ-EEEE-WWWW').should('have.attr', 'href', '/lpa/person/94/90');
+                    cy.contains('a', 'M-QQQQ-EEEE-WWWW').should('have.attr', 'href', '/lpa/frontend/lpa/M-QQQQ-EEEE-WWWW');
                     cy.contains('dt', 'Status').next().contains('Registered');
                     cy.contains('dt', 'Type').next().contains('Digital LPA - Personal welfare');
                 });
@@ -56,7 +56,7 @@ describe('Search component', () => {
             cy.get('.sirius-search__item:contains(Abelard Brroo, Donor)')
                 .eq(1)
                 .within(() => {
-                    cy.contains('a', 'M-1111-2222-3333').should('have.attr', 'href', '/lpa/person/94/78');
+                    cy.contains('a', 'M-1111-2222-3333').should('have.attr', 'href', '/lpa/frontend/lpa/M-1111-2222-3333');
                     cy.contains('dt', 'Status').next().contains('Pending');
                     cy.contains('dt', 'Type').next().contains('Digital LPA - Property and affairs');
                 });

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -23,18 +23,24 @@ export function formatAddress(address) {
 }
 
 const statusColourMap = {
-  Registered: "green",
+  Cancelled: "red",
+  "Cannot register": "red",
   Draft: "purple",
+  "De-registered": "red",
+  Deleted: "red",
+  "Do not register": "red",
+  Expired: "red",
+  "In progress": "light-blue",
   Perfect: "turquoise",
-  Pending: "yellow",
+  Pending: "blue",
   "Payment Pending": "blue",
   "Reduced Fees Pending": "blue",
-  Cancelled: "red",
+  Registered: "green",
   Rejected: "red",
   "Return - unpaid": "red",
   Revoked: "red",
+  "Statutory waiting period": "yellow",
   Withdrawn: "red",
-  Deleted: "red"
 };
 
 export function statusColour(status) {

--- a/src/main.js
+++ b/src/main.js
@@ -163,11 +163,17 @@ SearchResults.prototype.search = async function search() {
             )}, ${result.personType}
                     </strong>
                     <p class="${CLASSES.link}">
-                        <a class="govuk-link" href="/lpa/person/${result.id}/${
-              result.case.id
-            }">
+                        ${
+                          result.case.caseType === "DIGITAL_LPA"
+                            ? `
+                        <a class="govuk-link" href="/lpa/frontend/lpa/${result.case.uId}">
                             ${result.case.uId}
-                        </a>
+                        </a>`
+                            : `
+                        <a class="govuk-link" href="/lpa/person/${result.id}/${result.case.id}">
+                            ${result.case.uId}
+                        </a>`
+                        }
                     </p>
                     <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-0">
                         <div class="govuk-summary-list__row">


### PR DESCRIPTION
Go directly to LPA Frontend page, not to the old UI (which then redirects).

Also, update the status tag colours to match [upcoming changes to the frontend](https://github.com/ministryofjustice/opg-sirius-lpa-frontend/pull/573).

#minor