### PR TITLE
VEGA-3611: Show full results when searching from results page

### DIFF
--- a/cypress/e2e/search-results.html
+++ b/cypress/e2e/search-results.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Search results test document</title>
+  <script src="../../dist/search.js"></script>
+</head>
+<body>
+<form action="./search-results.html">
+  <input
+    data-module="sirius-search-preview"
+    name="term"
+    id="searchKeyword"
+    placeholder="Search..."
+    type="search"
+  />
+  <button type="submit">Search</button>
+</form>
+</body>
+</html>

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -7,6 +7,17 @@ const search = (term, fixture) => {
     cy.get('button').click();
 };
 
+describe('Search results page', () => {
+  it('Does not show preview when already on the search results page', () => {
+    cy.visit('./cypress/e2e/search-results.html');
+
+    cy.get('input').type('Giusto');
+    cy.get('button').click();
+
+    cy.url().should('include', '?term=Giusto');
+  });
+});
+
 describe('Search component', () => {
     describe('Search results', () => {
         it('Normalises case-number queries before calling the API', () => {

--- a/cypress/e2e/test.html
+++ b/cypress/e2e/test.html
@@ -9,7 +9,7 @@
     <script src="../../dist/search.js"></script>
   </head>
   <body>
-    <form>
+    <form action="/lpa/frontend/search">
       <label for="searchKeyword" class="govuk-visually-hidden"> Search </label>
       <input
         data-module="sirius-search-preview"

--- a/src/main.js
+++ b/src/main.js
@@ -288,12 +288,16 @@ document.addEventListener("submit", async (e) => {
     return;
   }
 
-  e.preventDefault();
-
   if ($input.value.trim() === "") {
+    e.preventDefault();
     return;
   }
 
-  new SearchResults($input, $form);
+  const formAction = new URL($form.action).pathname;
+  if (window.location.pathname === formAction) {
+    return;
+  }
 
+  e.preventDefault();
+  new SearchResults($input, $form);
 });


### PR DESCRIPTION
[VEGA-3611](https://opgtransform.atlassian.net/browse/VEGA-3611)

The submit handler in `main.js` was calling `e.preventDefault()` and  rendering the preview dropdown regardless of which page the search was submitted from. 
Added a comparison on the form's action path against the current page path. If they match, we assert that the user is already on the destination page so we let the form submit naturally as a GET request, which updates the search results in place with no preview dropdown.

counter part pr https://github.com/ministryofjustice/opg-sirius-lpa-frontend/pull/887

